### PR TITLE
KeySlots IDs as Enum

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+from key_slots import AutosarKeySlots
 from memory_update_protocol import *
+
 
 # Generate Memory Update Protocol Message (Basic SHE)
 def basic_she_memory_update_protocol() :
@@ -9,8 +11,8 @@ def basic_she_memory_update_protocol() :
         UID           = bytes.fromhex('000000000000000000000000000001'),
         KEY_NEW       = bytes.fromhex('0f0e0d0c0b0a09080706050403020100'),
         KEY_AuthID    = bytes.fromhex('000102030405060708090a0b0c0d0e0f'),
-        ID            = 0x04,
-        AuthID        = 0x01,
+        ID            = AutosarKeySlots.KEY_1,
+        AuthID        = AutosarKeySlots.MASTER_ECU_KEY,
         C_ID          = 0x01, # Counter value
         F_ID          = 0x00  # Flags
     )
@@ -32,8 +34,8 @@ def extend_she_memory_update_protocol() :
         UID           = bytes.fromhex('000000000000000000000000000001'),
         KEY_NEW       = bytes.fromhex('0f0e0d0c0b0a09080706050403020100'),
         KEY_AuthID    = bytes.fromhex('000102030405060708090a0b0c0d0e0f'),
-        ID            = 0x04,
-        AuthID        = 0x01,
+        ID            = AutosarKeySlots.KEY_1,
+        AuthID        = AutosarKeySlots.MASTER_ECU_KEY,
         C_ID          = 0x01, # Counter value
         F_ID          = 0x00  # Flags
     )
@@ -55,8 +57,8 @@ def advanced_she_memory_update_protocol() :
         UID           = bytes.fromhex('000000000000000000000000000001'),
         KEY_NEW       = bytes.fromhex('0f0e0d0c0b0a09080706050403020100'),
         KEY_AuthID    = bytes.fromhex('000102030405060708090a0b0c0d0e0f'),
-        ID            = 0x04,
-        AuthID        = 0x01,
+        ID            = AutosarKeySlots.KEY_1,
+        AuthID        = AutosarKeySlots.MASTER_ECU_KEY,
         C_ID          = 0x01, # Counter value
         F_ID          = 0x00  # Flags
     )

--- a/key_slots.py
+++ b/key_slots.py
@@ -1,0 +1,40 @@
+"""
+This file contains identification of memory slots.
+
+"""
+
+from enum import Enum
+
+__all__ = ["AutosarKeySlots", "KeySlots"]
+
+
+class KeySlots(Enum):
+    """
+    Enum to be inherited by user.
+    Every OEM may want it's own key slot identification.
+
+    """
+
+
+class AutosarKeySlots(KeySlots):
+    """
+    Enum holds memory slot identification based on
+    `Specification of Secure Hardware Extensions, AUTOSAR FO R19-11`.
+
+    """
+
+    SECRET_KEY = 0x0
+    MASTER_ECU_KEY = 0x1
+    BOOT_MAC_KEY = 0x2
+    BOOT_MAC = 0x3
+    KEY_1 = 0x4
+    KEY_2 = 0x5
+    KEY_3 = 0x6
+    KEY_4 = 0x7
+    KEY_5 = 0x8
+    KEY_6 = 0x9
+    KEY_7 = 0xA
+    KEY_8 = 0xB
+    KEY_9 = 0xC
+    KEY_10 = 0xD
+    RAM_KEY = 0xE

--- a/memory_update_protocol.py
+++ b/memory_update_protocol.py
@@ -4,68 +4,81 @@
 # Generate M1,M2,M3,M4,M5 message.
 # -----------------------------------------------------------------
 
-from dataclasses import dataclass
 from builtins import bytes
+from dataclasses import dataclass
+from typing import Union
+
 from Crypto.Cipher import AES
 from Crypto.Hash import CMAC
 
-@dataclass
-class MemoryUpdateInfo :
-    KEY_NEW             : bytes
-    KEY_AuthID          : bytes
-    UID                 : bytes
-    ID                  : int
-    AuthID              : int
-    C_ID                : int
-    F_ID                : int
+from key_slots import KeySlots
+
 
 @dataclass
-class MemoryUpdateMessage :
-    M1                  : bytes
-    M2                  : bytes
-    M3                  : bytes
-    M4                  : bytes
-    M5                  : bytes
+class MemoryUpdateInfo:
+    KEY_NEW: bytes
+    KEY_AuthID: bytes
+    UID: bytes
+    ID: Union[KeySlots, int]
+    AuthID: Union[KeySlots, int]
+    C_ID: int
+    F_ID: int
+
+
+@dataclass
+class MemoryUpdateMessage:
+    M1: bytes
+    M2: bytes
+    M3: bytes
+    M4: bytes
+    M5: bytes
+
 
 # Add constant values for flags
-WRITE_PROTECTION    = 0b100000
-BOOT_PROTECTION     = 0b010000
+WRITE_PROTECTION = 0b100000
+BOOT_PROTECTION = 0b010000
 DEBUGGER_PROTECTION = 0b001000
-KEY_USAGE           = 0b000100
-WILDCARD            = 0b000010
-VERIFY_ONLY         = 0b000001
+KEY_USAGE = 0b000100
+WILDCARD = 0b000010
+VERIFY_ONLY = 0b000001
+
 
 def encrypt_ecb(key, value):
     mode = AES.MODE_ECB
-    enc  = AES.new(key, mode)
+    enc = AES.new(key, mode)
     result = enc.encrypt(value)
     return result
 
-def encrypt_cbc(key, value, iv = bytes([0]*16)):
+
+def encrypt_cbc(key, value, iv=bytes([0] * 16)):
     mode = AES.MODE_CBC
-    enc  = AES.new(key, mode, iv = iv)
+    enc = AES.new(key, mode, iv=iv)
     result = enc.encrypt(value)
     return result
 
-def generate_cmac(key, msg) :
-    cmac = CMAC.new(key, ciphermod = AES)
+
+def generate_cmac(key, msg):
+    cmac = CMAC.new(key, ciphermod=AES)
     cmac.update(msg)
     return cmac.digest()
 
+
 def decrypt_ecb(key, value):
     mode = AES.MODE_ECB
-    enc  = AES.new(key, mode)
+    enc = AES.new(key, mode)
     result = enc.decrypt(value)
     return result
 
-def decrypt_cbc(key, value, iv = bytes([0]*16)):
+
+def decrypt_cbc(key, value, iv=bytes([0] * 16)):
     mode = AES.MODE_CBC
-    enc  = AES.new(key, mode, iv = iv)
+    enc = AES.new(key, mode, iv=iv)
     result = enc.decrypt(value)
     return result
 
-def verify_cmac(key, msg, digest) :
-    cmac = CMAC.new(key, ciphermod = AES)
+
+def verify_cmac(key, msg, digest):
+    cmac = CMAC.new(key, ciphermod=AES)
     cmac.update(msg)
     try:
         cmac.verify(digest)
@@ -74,65 +87,94 @@ def verify_cmac(key, msg, digest) :
         return False
 
 
-def array_xor(a,b):
+def array_xor(a, b):
     return bytes(x ^ y for x, y in zip(a, b))
+
 
 # Miyaguchi-Preneel one-way compression function
 # NOTE : data length must be  a multiple of 16byte.
 def mp_compress(data):
     l = len(data)
-    CHUNK_LEN = 16                # 128bit(16byte) chunks
+    CHUNK_LEN = 16  # 128bit(16byte) chunks
     out = bytes([0] * CHUNK_LEN)  # Initialization vector (IV) is zero.
 
     for i in range(0, l, CHUNK_LEN):
         chunk = data[i : i + CHUNK_LEN]
-        enc   = encrypt_ecb(out, chunk)
-        out   = array_xor(array_xor(enc, chunk), out)
+        enc = encrypt_ecb(out, chunk)
+        out = array_xor(array_xor(enc, chunk), out)
 
     return out
 
-def mp_kdf(k, c) :
+
+def mp_kdf(k, c):
     return mp_compress(k + c)
 
+
 # Generate Memory Update Protocol Message
-def generate_message(info, KEY_UPDATE_ENC_C, KEY_UPDATE_MAC_C) -> MemoryUpdateMessage :
+def generate_message(
+    info: MemoryUpdateInfo, KEY_UPDATE_ENC_C: bytes, KEY_UPDATE_MAC_C: bytes
+) -> MemoryUpdateMessage:
     k1 = mp_kdf(info.KEY_AuthID, KEY_UPDATE_ENC_C)
     k2 = mp_kdf(info.KEY_AuthID, KEY_UPDATE_MAC_C)
     k3 = mp_kdf(info.KEY_NEW, KEY_UPDATE_ENC_C)
     k4 = mp_kdf(info.KEY_NEW, KEY_UPDATE_MAC_C)
 
-    m1 = info.UID + ( (info.ID << 4) | (info.AuthID & 0x0F) ).to_bytes(1, 'big')
-    m2 = encrypt_cbc(k1, ((info.C_ID << 4) | (0x0F & (info.F_ID >> 2))).to_bytes(4, 'big') \
-                 + ((info.F_ID << 6) & 0xC0).to_bytes(1, 'big') \
-                 + bytes([0]*11) \
-                 + info.KEY_NEW )
+    if isinstance(info.ID, KeySlots):
+        info.ID = info.ID.value
+    if isinstance(info.AuthID, KeySlots):
+        info.AuthID = info.AuthID.value
+
+    m1 = info.UID + ((info.ID << 4) | (info.AuthID & 0x0F)).to_bytes(
+        1, "big"
+    )
+    m2 = encrypt_cbc(
+        k1,
+        ((info.C_ID << 4) | (0x0F & (info.F_ID >> 2))).to_bytes(4, "big")
+        + ((info.F_ID << 6) & 0xC0).to_bytes(1, "big")
+        + bytes([0] * 11)
+        + info.KEY_NEW,
+    )
     m3 = generate_cmac(k2, m1 + m2)
-    m4 = m1 + encrypt_ecb(k3, ((info.C_ID << 4) | 0x08).to_bytes(4, 'big') + bytes([0]*12))
+    m4 = m1 + encrypt_ecb(
+        k3, ((info.C_ID << 4) | 0x08).to_bytes(4, "big") + bytes([0] * 12)
+    )
     m5 = generate_cmac(k4, m4)
 
     return MemoryUpdateMessage(m1, m2, m3, m4, m5)
 
+
 # Generate Memory Update Protocol Message(Basic SHE)
-def generate_message_basic(info) -> MemoryUpdateMessage :
-    return generate_message(info, bytes.fromhex('010153484500800000000000000000B0'), bytes.fromhex('010253484500800000000000000000B0'))
+def generate_message_basic(info) -> MemoryUpdateMessage:
+    return generate_message(
+        info,
+        bytes.fromhex("010153484500800000000000000000B0"),
+        bytes.fromhex("010253484500800000000000000000B0"),
+    )
+
 
 # Generate Memory Update Protocol Message(SHE+)
-def generate_message_extend(info) -> MemoryUpdateMessage :
-    return generate_message(info, bytes.fromhex('018153484500800000000000000000B0'), bytes.fromhex('018253484500800000000000000000B0'))
+def generate_message_extend(info) -> MemoryUpdateMessage:
+    return generate_message(
+        info,
+        bytes.fromhex("018153484500800000000000000000B0"),
+        bytes.fromhex("018253484500800000000000000000B0"),
+    )
 
 
 # Decrypt SHE M* values
-def decrypt_message(KEY_AuthID, message, KEY_UPDATE_ENC_C, KEY_UPDATE_MAC_C) -> MemoryUpdateInfo:
+def decrypt_message(
+    KEY_AuthID, message, KEY_UPDATE_ENC_C, KEY_UPDATE_MAC_C
+) -> MemoryUpdateInfo:
     k1 = mp_kdf(KEY_AuthID, KEY_UPDATE_ENC_C)
     k2 = mp_kdf(KEY_AuthID, KEY_UPDATE_MAC_C)
     UID = bytes.fromhex(message.M1.hex()[0:30])
-    ID = int(message.M1.hex()[30],16)
-    AuthID = int(message.M1.hex()[31],16)
-    dec = decrypt_cbc(k1,message.M2).hex()
-    C_ID = int(dec[0:7],16)
-    F_ID = int(dec[7:9],16)>>2
+    ID = int(message.M1.hex()[30], 16)
+    AuthID = int(message.M1.hex()[31], 16)
+    dec = decrypt_cbc(k1, message.M2).hex()
+    C_ID = int(dec[0:7], 16)
+    F_ID = int(dec[7:9], 16) >> 2
     KEY_NEW = bytes.fromhex(dec[32:64])
-    if(verify_cmac(k2, message.M1 + message.M2, message.M3)):
-        return True, MemoryUpdateInfo(KEY_NEW, KEY_AuthID, UID, ID, AuthID, C_ID,F_ID)
+    if verify_cmac(k2, message.M1 + message.M2, message.M3):
+        return True, MemoryUpdateInfo(KEY_NEW, KEY_AuthID, UID, ID, AuthID, C_ID, F_ID)
     else:
-        return False, MemoryUpdateInfo(KEY_NEW, KEY_AuthID, UID, ID, AuthID, C_ID,F_ID)
+        return False, MemoryUpdateInfo(KEY_NEW, KEY_AuthID, UID, ID, AuthID, C_ID, F_ID)


### PR DESCRIPTION
Hello,

Let me propose a little upgrade - https://www.autosar.org/fileadmin/user_upload/standards/foundation/19-11/AUTOSAR_TR_SecureHardwareExtensions.pdf defines key slots with their own identifiers.
Let's help users with more readable code by usage of Enum.
Of course, every user want to have it's own implementation of Key IDs, so that the reason `KeySlots` was added - user can inherit and create his own enum.

Used `isort` and `black` tools for formatting.